### PR TITLE
Use "Native" copyright instead of ©️

### DIFF
--- a/Sources/Components/Footer.swift
+++ b/Sources/Components/Footer.swift
@@ -3,7 +3,7 @@ import Foundation
 struct Footer: Component {
     var body: some Component {
         Tag("footer") {
-            P { "Copyright ©️ Khan Winter \(Date().year)" }
+            P { "Copyright &copy; Khan Winter \(Date().year)" }
             P { A("https://github.com/thecoolwinter/blog") { "Built In Swift" } }
             P {
                 A("https://twitter.com/thecoolwinter", ["rel": "me", "target": "_blank"]) { "Twitter" }


### PR DESCRIPTION
The ©️ looks out of place on a Windows machine.

![image](https://github.com/user-attachments/assets/67206fef-d274-4654-98fa-b33abea741b3)
